### PR TITLE
API to allow logfile uploading

### DIFF
--- a/podium_api/api.py
+++ b/podium_api/api.py
@@ -37,7 +37,12 @@ from podium_api.friendships import (
     make_friendships_get,
 )
 from podium_api.laps import make_lap_get, make_laps_get
-from podium_api.logfiles import make_logfile_create, make_logfile_new
+from podium_api.logfiles import (
+    make_logfile_create,
+    make_logfile_get,
+    make_logfile_new,
+    make_logfiles_get,
+)
 from podium_api.presets import (
     make_preset_create,
     make_preset_delete,
@@ -1796,8 +1801,12 @@ class PodiumLogfilesAPI(object):
         """
         Request that prepares a logfile for upload
 
-        The uri for the newly created rating will be provided to the
-        redirect_callback if one is provided in the form of a PodiumRedirect.
+        The response will be a partially populated logfile object with the following fields populated:
+            upload_url (str): the URL used for uploading the file
+
+            eventdevice_id (int): the eventdevice id associated with this logfile upload. Used in the create operation
+
+            file_key (str): the key representing the file that will be uploaded using the upload_url. Used in the create operation
 
         Args:
             device_id (int): ID of the device the logfile will be associated with.
@@ -1869,3 +1878,87 @@ class PodiumLogfilesAPI(object):
 
         """
         make_logfile_create(self.token, *args, **kwargs)
+
+    def list(self, *args, **kwargs):
+        """
+        Request that returns a PodiumPagedRequest of logfiles.
+        By default a get request to
+        'https://podium.live/api/v1/logfiles' will be made.
+
+        Kwargs:
+            expand (bool): Expand all objects in response output.
+            Defaults to True
+
+            quiet (object): If not None HTML layout will not render endpoint
+            description. Defaults to None.
+
+            success_callback (function): Callback for a successful request,
+            will have the signature:
+                on_success(PodiumPagedResponse)
+            Defaults to None.
+
+            failure_callback (function): Callback for failures and errors.
+            Will have the signature:
+                on_failure(failure_type (string), result (dict), data (dict))
+            Values for failure type are: 'error', 'failure'. Defaults to None.
+
+            redirect_callback (function): Callback for redirect,
+            Will have the signature:
+                on_redirect(result (dict), data (dict))
+            Defaults to None.
+
+            progress_callback (function): Callback for progress updates,
+            will have the signature:
+                on_progress(current_size (int), total_size (int), data (dict))
+            Defaults to None.
+
+            start (int): Starting index for logfiles list. 0 indexed.
+
+            per_page (int): Number per page of results, max of 100.
+
+            endpoint (str): If provided the start, per_page, expand, and quiet
+            params will not be used instead making a request based on the
+            provided endpoint.
+
+        Return:
+            UrlRequest: The request being made.
+
+        """
+        make_logfiles_get(self.token, *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        """
+        Request that returns a PodiumLogfile for the provided logfile_uri.
+
+        Args:
+            logfile_uri (str): URI for the logfile you want.
+
+        Kwargs:
+            expand (bool): Expand all objects in response output.
+            Defaults to True
+
+            success_callback (function): Callback for a successful request,
+            will have the signature:
+                on_success(PodiumLogfile)
+            Defaults to None.
+
+            failure_callback (function): Callback for failures and errors.
+            Will have the signature:
+                on_failure(failure_type (string), result (dict), data (dict))
+            Values for failure type are: 'error', 'failure'. Defaults to None.
+
+            redirect_callback (function): Callback for redirect,
+            Will have the signature:
+                on_redirect(result (dict), data (dict))
+            Defaults to None.
+
+            progress_callback (function): Callback for progress updates,
+            will have the signature:
+                on_progress(current_size (int), total_size (int), data (dict))
+            Defaults to None.
+
+        Return:
+            UrlRequest: The request being made.
+
+        """
+        make_logfile_get(self.token, *args, **kwargs)

--- a/podium_api/api.py
+++ b/podium_api/api.py
@@ -37,6 +37,7 @@ from podium_api.friendships import (
     make_friendships_get,
 )
 from podium_api.laps import make_lap_get, make_laps_get
+from podium_api.logfiles import make_logfile_create, make_logfile_new
 from podium_api.presets import (
     make_preset_create,
     make_preset_delete,
@@ -99,6 +100,7 @@ class PodiumAPI(object):
         self.alertmessages = PodiumAlertMessagesAPI(token)
         self.presets = PodiumPresetsAPI(token)
         self.ratings = PodiumRatingsAPI(token)
+        self.logfiles = PodiumLogfilesAPI(token)
 
         self.podium_account = None
         self.podium_user = None
@@ -1774,3 +1776,96 @@ class PodiumRatingsAPI(object):
 
         """
         make_rating_create(self.token, *args, **kwargs)
+
+
+class PodiumLogfilesAPI(object):
+    """
+    Object that handles Logfiles and keeps track of the
+    authentication token necessary to do so. Usually accessed via
+    PodiumAPI object.
+
+    **Attributes:**
+        **token** (PodiumToken): The token for the logged in user.
+
+    """
+
+    def __init__(self, token):
+        self.token = token
+
+    def new(self, *args, **kwargs):
+        """
+        Request that prepares a logfile for upload
+
+        The uri for the newly created rating will be provided to the
+        redirect_callback if one is provided in the form of a PodiumRedirect.
+
+        Args:
+            device_id (int): ID of the device the logfile will be associated with.
+
+            event_id (int): ID of the event the logfile will be associated with.
+
+        Kwargs:
+            success_callback (function): Callback for a successful request,
+            will have the signature:
+                on_success(result (dict), data (dict))
+            Defaults to None.
+
+            failure_callback (function): Callback for failures and errors.
+            Will have the signature:
+                on_failure(failure_type (string), result (dict), data (dict))
+            Values for failure type are: 'error', 'failure'. Defaults to None.
+
+            redirect_callback (function): Callback for redirect,
+            Will have the signature:
+                on_redirect(redirect_object (PodiumRedirect))
+            Defaults to None.
+
+            progress_callback (function): Callback for progress updates,
+            will have the signature:
+                on_progress(current_size (int), total_size (int), data (dict))
+            Defaults to None.
+
+        Return:
+            UrlRequest: The request being made.
+
+        """
+        make_logfile_new(self.token, *args, **kwargs)
+
+    def create(self, *args, **kwargs):
+        """
+        Request that creates or updates a PodiumLogfile.
+
+        The uri for the newly created rating will be provided to the
+        redirect_callback if one is provided in the form of a PodiumRedirect.
+
+        Args:
+            file_key (string): key representing the file that will be uploaded. Provided by the new method.
+
+            eventdevice_id (int): The eventdevice ID associated with the upload. Provided by the new method.
+
+        Kwargs:
+            success_callback (function): Callback for a successful request,
+            will have the signature:
+                on_success(result (dict), data (dict))
+            Defaults to None.
+
+            failure_callback (function): Callback for failures and errors.
+            Will have the signature:
+                on_failure(failure_type (string), result (dict), data (dict))
+            Values for failure type are: 'error', 'failure'. Defaults to None.
+
+            redirect_callback (function): Callback for redirect,
+            Will have the signature:
+                on_redirect(redirect_object (PodiumRedirect))
+            Defaults to None.
+
+            progress_callback (function): Callback for progress updates,
+            will have the signature:
+                on_progress(current_size (int), total_size (int), data (dict))
+            Defaults to None.
+
+        Return:
+            UrlRequest: The request being made.
+
+        """
+        make_logfile_create(self.token, *args, **kwargs)

--- a/podium_api/friendships.py
+++ b/podium_api/friendships.py
@@ -284,7 +284,7 @@ def create_friendship_redirect_handler(req, results, data):
     """
     Handles the success redirect of a **make_friendship_create** call.
 
-    Returns a PodiumRedirect with a uri for the newly created event to the
+    Returns a PodiumRedirect with a uri for the newly created friendship to the
     _redirect_callback found in data.
 
     Automatically called by **make_friendship_create**, will call the

--- a/podium_api/logfiles.py
+++ b/podium_api/logfiles.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import podium_api
+from podium_api.asyncreq import get_json_header_token, make_request_custom_success
+from podium_api.types.logfile import get_logfile_from_json
+from podium_api.types.redirect import get_redirect_from_json
+
+
+def make_logfile_get(
+    token,
+    endpoint,
+    device_id,
+    event_id,
+    success_callback=None,
+    failure_callback=None,
+    progress_callback=None,
+    redirect_callback=None,
+):
+    """
+    Request that prepares a logfile upload, returning a presigned URL for uploading the logfile which can be POSTed.
+
+    Args:
+        token (PodiumToken): The authentication token for this session.
+
+        endpoint (str): The endpoint to make the request too.
+
+        device_id (int): The ID of the device associated with this logfile
+
+    Kwargs:
+        event_id (int): The ID of the event to associate with this logfile.
+        Defaults to None. If None, an event will be auto-selected or auto-created as needed
+
+        success_callback (function): Callback for a successful request,
+        will have the signature:
+            on_success(PodiumPagedResponse)
+        Defaults to None.
+
+        failure_callback (function): Callback for failures and errors.
+        Will have the signature:
+            on_failure(failure_type (string), result (dict), data (dict))
+        Values for failure type are: 'error', 'failure'. Defaults to None.
+
+        progress_callback (function): Callback for progress updates,
+        will have the signature:
+            on_progress(current_size (int), total_size (int), data (dict))
+        Defaults to None.
+
+    Return:
+        UrlRequest: The request being made.
+
+    """
+    params = {}
+    params["device_id"] = device_id
+    if event_id is not None:
+        params["event_id"] = event_id
+
+    header = get_json_header_token(token)
+    return make_request_custom_success(
+        endpoint,
+        logfile_success_handler,
+        method="GET",
+        success_callback=success_callback,
+        failure_callback=failure_callback,
+        progress_callback=progress_callback,
+        redirect_callback=redirect_callback,
+        params=params,
+        header=header,
+    )
+
+
+def make_logfile_create(
+    token,
+    file_key,
+    eventdevice_id,
+    success_callback=None,
+    failure_callback=None,
+    progress_callback=None,
+    redirect_callback=None,
+):
+    """
+    Request that adds a logfile for the user whose token is in use.
+
+    The uri for the newly created event will be provided to the
+    redirect_callback if one is provided in the form of a PodiumRedirect.
+
+    Args:
+        token (PodiumToken): The authentication token for this session.
+
+    Kwargs:
+        success_callback (function): Callback for a successful request,
+        will have the signature:
+            on_success(result (dict), data (dict))
+        Defaults to None..
+
+        failure_callback (function): Callback for failures and errors.
+        Will have the signature:
+            on_failure(failure_type (string), result (dict), data (dict))
+        Values for failure type are: 'error', 'failure'. Defaults to None.
+
+        progress_callback (function): Callback for progress updates,
+        will have the signature:
+            on_progress(current_size (int), total_size (int), data (dict))
+        Defaults to None.
+
+    Return:
+        UrlRequest: The request being made.
+
+    """
+    endpoint = "{}/api/v1/logfiles".format(podium_api.PODIUM_APP.podium_url)
+    body = {"logfile[file_key]": file_key, "logfile[eventdevice_id]": eventdevice_id}
+    header = get_json_header_token(token)
+    return make_request_custom_success(
+        endpoint,
+        None,
+        method="POST",
+        success_callback=success_callback,
+        redirect_callback=create_logfile_redirect_handler,
+        failure_callback=failure_callback,
+        progress_callback=progress_callback,
+        body=body,
+        header=header,
+        data={"_redirect_callback": redirect_callback},
+    )
+
+
+def logfile_success_handler(req, results, data):
+    """
+    Creates and returns a PodiumLogfile.
+    Called automatically by **make_logfile_get**.
+
+    Args:
+        req (UrlRequest): Instace of the request that was made.
+
+        results (dict): Dict returned by the request.
+
+        data (dict): Wildcard dict for containing data that needs to be passed
+        to the various callbacks of a request. Will contain at least a
+        'success_callback' key.
+
+    Return:
+        None, this function instead calls a callback.
+
+    """
+    if data["success_callback"] is not None:
+        data["success_callback"](get_logfile_from_json(results["logfile"]))
+
+
+def create_logfile_redirect_handler(req, results, data):
+    """
+    Handles the success redirect of a **make_logfile_create** call.
+
+    Returns a PodiumRedirect with a uri for the newly created logfile to the
+    _redirect_callback found in data.
+
+    Automatically called by **make_logfile_create**, will call the
+    redirect_callback passed in to **make_logfile_create** if there is one.
+
+    Args:
+        req (UrlRequest): Instace of the request that was made.
+
+        results (dict): Dict returned by the request.
+
+        data (dict): Wildcard dict for containing data that needs to be passed
+        to the various callbacks of a request. Will contain at least a
+        'success_callback' key.
+
+    Return:
+        None, this function instead calls a callback.
+
+    """
+    if data["_redirect_callback"] is not None:
+        data["_redirect_callback"](get_redirect_from_json(results, "logfile"))

--- a/podium_api/logfiles.py
+++ b/podium_api/logfiles.py
@@ -3,6 +3,7 @@
 import podium_api
 from podium_api.asyncreq import get_json_header_token, make_request_custom_success
 from podium_api.types.logfile import get_logfile_from_json
+from podium_api.types.paged_response import get_paged_response_from_json
 from podium_api.types.redirect import get_redirect_from_json
 
 
@@ -57,6 +58,146 @@ def make_logfile_new(
     header = get_json_header_token(token)
     return make_request_custom_success(
         endpoint,
+        logfile_success_handler,
+        method="GET",
+        success_callback=success_callback,
+        failure_callback=failure_callback,
+        progress_callback=progress_callback,
+        redirect_callback=redirect_callback,
+        params=params,
+        header=header,
+    )
+
+
+def make_logfiles_get(
+    token,
+    start=None,
+    per_page=None,
+    expand=True,
+    success_callback=None,
+    redirect_callback=None,
+    failure_callback=None,
+    progress_callback=None,
+):
+    """
+    Request that returns a PodiumPagedRequest of Logfiles for the user's account.
+
+    Args:
+        token (PodiumToken): The authentication token for this session.
+
+        endpoint (str): the endpoint to make the request to.
+
+    Kwargs:
+        expand (bool): Expand all objects in response output. Defaults to True
+
+        success_callback (function): Callback for a successful request,
+        will have the signature:
+            on_success(PodiumPagedResponse)
+        Defaults to None.
+
+        failure_callback (function): Callback for failures and errors.
+        Will have the signature:
+            on_failure(failure_type (string), result (dict), data (dict))
+        Values for failure type are: 'error', 'failure'. Defaults to None.
+
+        redirect_callback (function): Callback for redirect,
+        Will have the signature:
+            on_redirect(result (dict), data (dict))
+        Defaults to None.
+
+        progress_callback (function): Callback for progress updates,
+        will have the signature:
+            on_progress(current_size (int), total_size (int), data (dict))
+        Defaults to None.
+
+        start (int): Starting index for events list. 0 indexed.
+
+        per_page (int): Number per page of results, max of 100.
+
+    Return:
+        UrlRequest: The request being made.
+
+    """
+    params = {}
+    if expand is not None:
+        params["expand"] = expand
+    if start is not None:
+        params["start"] = start
+    if per_page is not None:
+        per_page = min(per_page, 100)
+        params["per_page"] = per_page
+
+    endpoint = "{}/api/v1/logfiles".format(podium_api.PODIUM_APP.podium_url)
+    header = get_json_header_token(token)
+    return make_request_custom_success(
+        endpoint,
+        logfiles_success_handler,
+        method="GET",
+        success_callback=success_callback,
+        failure_callback=failure_callback,
+        progress_callback=progress_callback,
+        redirect_callback=redirect_callback,
+        params=params,
+        header=header,
+    )
+
+
+def make_logfile_get(
+    token,
+    logfile_uri,
+    expand=True,
+    quiet=None,
+    success_callback=None,
+    redirect_callback=None,
+    failure_callback=None,
+    progress_callback=None,
+):
+    """
+    Request that returns a PodiumLogfile for the provided logfile_uri
+
+    Args:
+        token (PodiumToken): The authentication token for this session.
+
+        logfile_uri (str): URI for the logfile you want.
+
+    Kwargs:
+        expand (bool): Expand all objects in response output. Defaults to True
+
+        quiet (object): If not None HTML layout will not render endpoint
+        description. Defaults to None.
+
+        success_callback (function): Callback for a successful request,
+        will have the signature:
+            on_success(PodiumEvent)
+        Defaults to None.
+
+        failure_callback (function): Callback for failures and errors.
+        Will have the signature:
+            on_failure(failure_type (string), result (dict), data (dict))
+        Values for failure type are: 'error', 'failure'. Defaults to None.
+
+        redirect_callback (function): Callback for redirect,
+        Will have the signature:
+            on_redirect(result (dict), data (dict))
+        Defaults to None.
+
+        progress_callback (function): Callback for progress updates,
+        will have the signature:
+            on_progress(current_size (int), total_size (int), data (dict))
+        Defaults to None.
+
+    Return:
+        UrlRequest: The request being made.
+
+    """
+    params = {}
+    if expand is not None:
+        params["expand"] = expand
+    if quiet is not None:
+        params["quiet"] = quiet
+    header = get_json_header_token(token)
+    return make_request_custom_success(
+        logfile_uri,
         logfile_success_handler,
         method="GET",
         success_callback=success_callback,
@@ -170,3 +311,27 @@ def create_logfile_redirect_handler(req, results, data):
     """
     if data["_redirect_callback"] is not None:
         data["_redirect_callback"](get_redirect_from_json(results, "logfile"))
+
+
+def logfiles_success_handler(req, results, data):
+    """
+    Creates and returns a PodiumPagedResponse with Logfile as the payload
+    to the success_callback found in data if there is one.
+
+    Called automatically by **make_logfiles_get**.
+
+    Args:
+        req (UrlRequest): Instance of the request that was made.
+
+        results (dict): Dict returned by the request.
+
+        data (dict): Wildcard dict for containing data that needs to be passed
+        to the various callbacks of a request. Will contain at least a
+        'success_callback' key.
+
+    Return:
+        None, this function instead calls a callback.
+
+    """
+    if data["success_callback"] is not None:
+        data["success_callback"](get_paged_response_from_json(results, "logfiles"))

--- a/podium_api/logfiles.py
+++ b/podium_api/logfiles.py
@@ -6,9 +6,8 @@ from podium_api.types.logfile import get_logfile_from_json
 from podium_api.types.redirect import get_redirect_from_json
 
 
-def make_logfile_get(
+def make_logfile_new(
     token,
-    endpoint,
     device_id,
     event_id,
     success_callback=None,
@@ -49,6 +48,7 @@ def make_logfile_get(
         UrlRequest: The request being made.
 
     """
+    endpoint = "{}/api/v1/logfiles/new".format(podium_api.PODIUM_APP.podium_url)
     params = {}
     params["device_id"] = device_id
     if event_id is not None:

--- a/podium_api/types/logfile.py
+++ b/podium_api/types/logfile.py
@@ -20,11 +20,37 @@ class PodiumLogfile(object):
           STATUS_COMPLETED = 3
     """
 
-    def __init__(self, upload_url, file_key, eventdevice_id, status):
-        self.upload_url = upload_url
+    def __init__(
+        self,
+        file_key,
+        eventdevice_id,
+        status,
+        id=None,
+        URI=None,
+        upload_url=None,
+        event_id=None,
+        event_url=None,
+        event_title=None,
+        device_id=None,
+        device_url=None,
+        device_name=None,
+        created=None,
+    ):
         self.file_key = file_key
         self.eventdevice_id = eventdevice_id
         self.status = status
+
+        self.id = id
+        self.URI = URI
+        self.upload_url = upload_url
+
+        self.event_id = event_id
+        self.event_url = event_url
+        self.event_title = event_title
+        self.device_id = device_id
+        self.device_url = device_url
+        self.device_name = device_name
+        self.created = created
 
 
 def get_logfile_from_json(json):
@@ -39,4 +65,18 @@ def get_logfile_from_json(json):
         PodiumFriendship: The PodiumFriendship object for the data.
 
     """
-    return PodiumLogfile(json["upload_url"], json["file_key"], json["eventdevice_id"], json["status"])
+    return PodiumLogfile(
+        json["file_key"],
+        json["eventdevice_id"],
+        json["status"],
+        json.get("id", None),
+        json.get("URI", None),
+        json.get("upload_url", None),
+        json.get("event_id", None),
+        json.get("event_url", None),
+        json.get("event_title", None),
+        json.get("device_id", None),
+        json.get("device_url", None),
+        json.get("device_name", None),
+        json.get("created", None),
+    )

--- a/podium_api/types/logfile.py
+++ b/podium_api/types/logfile.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+class PodiumLogfile(object):
+    """
+    Object that represents a Logfile
+
+    **Attributes:**
+
+        **upload_url** (string): URL used to upload the actual logfile
+
+        **file_key** (string): key of logfile, used later to start the import process after the log file is uploaded using the URL
+
+        **eventdevice_id** (id): The ID of the eventdevice associated with this upload
+
+        **status** (int): The state of this logfile, where
+          STATUS_UNQUEUED= -1
+          STATUS_ERROR = 0
+          STATUS_QUEUED = 1
+          STATUS_PROCESSING = 2
+          STATUS_COMPLETED = 3
+    """
+
+    def __init__(self, upload_url, file_key, eventdevice_id, status):
+        self.upload_url = upload_url
+        self.file_key = file_key
+        self.eventdevice_id = eventdevice_id
+        self.status = status
+
+
+def get_logfile_from_json(json):
+    """
+    Returns a PodiumLogfile object from the json dict received from
+    podium api.
+
+    Args:
+        json (dict): Dict of data from REST api
+
+    Return:
+        PodiumFriendship: The PodiumFriendship object for the data.
+
+    """
+    return PodiumLogfile(json["upload_url"], json["file_key"], json["eventdevice_id"], json["status"])

--- a/podium_api/types/paged_response.py
+++ b/podium_api/types/paged_response.py
@@ -6,6 +6,7 @@ from podium_api.types.event import get_event_from_json
 from podium_api.types.eventdevice import get_eventdevice_from_json
 from podium_api.types.friendship import get_friendship_from_json
 from podium_api.types.lap import get_lap_from_json
+from podium_api.types.logfile import get_logfile_from_json
 from podium_api.types.preset import get_preset_from_json
 from podium_api.types.user import get_user_from_json
 from podium_api.types.venue import get_venue_from_json
@@ -53,6 +54,7 @@ PAYLOAD_NAME_TO_OBJECT = {
     "venues": get_venue_from_json,
     "alertmessages": get_alertmessage_from_json,
     "presets": get_preset_from_json,
+    "logfiles": get_logfile_from_json,
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name="podium_api",
     packages=["podium_api", "podium_api.types"],
-    version="0.0.30",
+    version="0.1.0",
     description="API for Podium Motorsports Platform http://podium.live",
     author="Autosport Labs",
     author_email="sales@autosportlabs.com",

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -11,6 +11,7 @@ from podium_api.devices import (
     make_device_delete,
     make_device_get,
     make_device_update,
+    make_devices_get,
 )
 from podium_api.types.device import get_device_from_json
 from podium_api.types.redirect import get_redirect_from_json
@@ -476,6 +477,148 @@ class TestDeviceUpdate(unittest.TestCase):
                 "progress_callback": progress_cb,
                 "redirect_callback": None,
                 "updated_uri": "https://podium.live/api/v1/devices/test",
+            },
+        )
+
+    def tearDown(self):
+        podium_api.unregister_podium_application()
+
+
+class TestDevicesGet(unittest.TestCase):
+    def setUp(self):
+        podium_api.register_podium_application("test_id", "test_secret")
+        self.token = PodiumToken("test_token", "test_type", 1)
+
+        self.result_json = {
+            "id": "test",
+            "URI": "https://podium.live/api/v1/devices/test",
+            "serial": "test_serial",
+            "private": False,
+            "name": "test_device",
+            "avatar_url": "https://avatar_url/image.jpg",
+        }
+        self.field_names = {"id": "device_id", "URI": "uri"}
+
+        self.paged_device_json = {"total": 1, "devices": [self.result_json]}
+
+    def check_results_device(self):
+        for key in self.result_json:
+            if key in self.field_names:
+                rkey = self.field_names[key]
+            else:
+                rkey = key
+            self.assertEqual(getattr(self.result, rkey), self.result_json[key])
+
+    def check_results_paged_response(self):
+        result = self.result
+        self.assertEqual(result.total, 1)
+        self.assertEqual(result.next_uri, None)
+        self.assertEqual(result.prev_uri, None)
+        self.assertEqual(result.payload_name, "devices")
+        for device in result.devices:
+            self.result = device
+            self.check_results_device()
+
+    def test_get_device_from_json(self):
+        self.result = get_device_from_json(self.result_json)
+        self.check_results_device()
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_no_params(self, mock_request):
+        req = make_devices_get(
+            self.token,
+            expand=None,
+            success_callback=self.success_cb,
+        )
+        self.assertEqual(req.url, "https://podium.live/api/v1/devices")
+
+    def success_cb(self, result):
+        self.result = result
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_devices_get(self, mock_request):
+        req = make_devices_get(self.token, start=0, per_page=100, success_callback=self.success_cb)
+        self.assertEqual(req._method, "GET")
+        self.assertTrue("https://podium.live/api/v1/devices?" in req.url)
+        self.assertTrue("per_page=100" in req.url)
+        self.assertTrue("start=0" in req.url)
+        self.assertTrue("expand=True" in req.url)
+        self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
+        self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
+        self.assertEqual(req.req_headers["Accept"], "application/json")
+        # simulate successful request
+        req.on_success()(req, self.paged_device_json)
+        self.check_results_paged_response()
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_error_callback(self, mock_request):
+        error_cb = Mock()
+        req = make_devices_get(self.token, start=0, per_page=100, failure_callback=error_cb)
+        # simulate calling the requests on_error
+        req.on_error()(req, {})
+        # assert our lambda called the mock correctly
+        error_cb.assert_called_with(
+            "error",
+            {},
+            {
+                "success_callback": None,
+                "failure_callback": error_cb,
+                "progress_callback": None,
+                "redirect_callback": None,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_failure_callback(self, mock_request):
+        error_cb = Mock()
+        req = make_devices_get(self.token, start=0, per_page=100, failure_callback=error_cb)
+        # simulate calling the requests on_failure
+        req.on_failure()(req, {})
+        # assert our lambda called the mock correctly
+        error_cb.assert_called_with(
+            "failure",
+            {},
+            {
+                "success_callback": None,
+                "failure_callback": error_cb,
+                "progress_callback": None,
+                "redirect_callback": None,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_redirect_callback(self, mock_request):
+        redir_cb = Mock()
+        req = make_devices_get(self.token, start=0, per_page=100, redirect_callback=redir_cb)
+        # simulate calling the requests on_redirect
+        req.on_redirect()(req, {})
+        # assert our lambda called the mock correctly
+        redir_cb.assert_called_with(
+            req,
+            None,
+            {
+                "success_callback": None,
+                "failure_callback": None,
+                "progress_callback": None,
+                "redirect_callback": redir_cb,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_progress_callback(self, mock_request):
+        progress_cb = Mock()
+        req = make_devices_get(self.token, start=0, per_page=100, progress_callback=progress_cb)
+        # simulate calling the requests on_progress
+        req.on_progress()(req, 0, 10)
+        # assert our lambda called the mock correctly
+        progress_cb.assert_called_with(
+            0,
+            10,
+            {
+                "success_callback": None,
+                "failure_callback": None,
+                "progress_callback": progress_cb,
+                "redirect_callback": None,
             },
         )
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -58,7 +58,7 @@ class TestEventsGet(unittest.TestCase):
             self.result = event
             self.check_results_event()
 
-    def test_get_account_from_json(self):
+    def test_get_event_from_json(self):
         self.result = get_event_from_json(self.result_json)
         self.check_results_event()
 

--- a/tests/test_friendships.py
+++ b/tests/test_friendships.py
@@ -242,6 +242,7 @@ class TestFriendshipsGet(unittest.TestCase):
             "id": "test",
             "URI": "test/users/test",
             "username": "test_user",
+            "name": "test name",
             "description": None,
             "avatar_url": "test/avatar/img.png",
             "links": None,
@@ -251,6 +252,7 @@ class TestFriendshipsGet(unittest.TestCase):
             "profile_image_url": "test/avatar/img.png",
             "events_uri": "test/events",
             "venues_uri": "test/venues",
+            "permalink": "test/permalink",
         }
         self.paged_event_json = {"total": 1, "users": [self.result_json]}
         self.field_names = {"id": "user_id", "URI": "uri"}

--- a/tests/test_logfiles.py
+++ b/tests/test_logfiles.py
@@ -8,7 +8,9 @@ import podium_api
 from podium_api.logfiles import (
     create_logfile_redirect_handler,
     make_logfile_create,
+    make_logfile_get,
     make_logfile_new,
+    make_logfiles_get,
 )
 from podium_api.types.logfile import get_logfile_from_json
 from podium_api.types.redirect import get_redirect_from_json
@@ -237,6 +239,295 @@ class TestLogfileNew(unittest.TestCase):
             event_id=5678,
             progress_callback=progress_cb,
         )
+        # simulate calling the requests on_progress
+        req.on_progress()(req, 0, 10)
+        # assert our lambda called the mock correctly
+        progress_cb.assert_called_with(
+            0,
+            10,
+            {
+                "success_callback": None,
+                "failure_callback": None,
+                "progress_callback": progress_cb,
+                "redirect_callback": None,
+            },
+        )
+
+    def tearDown(self):
+        podium_api.unregister_podium_application()
+
+
+class TestLogfileGet(unittest.TestCase):
+    def setUp(self):
+        podium_api.register_podium_application("test_id", "test_secret")
+        self.token = PodiumToken("test_token", "test_type", 1)
+        self.result_json = {
+            "id": 111,
+            "URI": "https://podium.live/api/v1/logfile/111",
+            "file_key": "123456",
+            "eventdevice_id": 1234,
+            "status": 2,
+            "event_id": 333,
+            "event_url": "https://podium.live/api/v1/events/222",
+            "device_id": 444,
+            "device_url": "https://podium.live/api/v1/devices/333",
+            "created": "2023-09-04T09:38:18Z",
+        }
+        self.field_names = {
+            "id": "id",
+            "URI": "URI",
+            "file_key": "file_key",
+            "eventdevice_id": "eventdevice_id",
+            "status": "status",
+            "event_id": "event_id",
+            "event_url": "event_url",
+            "device_id": "device_id",
+            "device_url": "device_url",
+            "created": "created",
+        }
+
+    def check_results(self):
+        for key in self.result_json:
+            if key in self.field_names:
+                rkey = self.field_names[key]
+            else:
+                rkey = key
+            self.assertEqual(getattr(self.result, rkey), self.result_json[key])
+
+    def test_get_account_from_json(self):
+        self.result = get_logfile_from_json(self.result_json)
+        self.check_results()
+
+    def success_cb(self, result):
+        self.result = result
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_logfile_get(self, mock_request):
+        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfiles/test", success_callback=self.success_cb)
+        self.assertEqual(req._method, "GET")
+        self.assertEqual(req.url, "https://podium.live/api/v1/logfiles/test?expand=True")
+        self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
+        self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
+        self.assertEqual(req.req_headers["Accept"], "application/json")
+        # simulate successful request
+        req.on_success()(req, {"logfile": self.result_json})
+        self.check_results()
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_error_callback(self, mock_request):
+        error_cb = Mock()
+        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfiles/111", failure_callback=error_cb)
+        # simulate calling the requests on_error
+        req.on_error()(req, {})
+        # assert our lambda called the mock correctly
+        error_cb.assert_called_with(
+            "error",
+            {},
+            {
+                "success_callback": None,
+                "failure_callback": error_cb,
+                "progress_callback": None,
+                "redirect_callback": None,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_failure_callback(self, mock_request):
+        error_cb = Mock()
+        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfiles/111", failure_callback=error_cb)
+        # simulate calling the requests on_failure
+        req.on_failure()(req, {})
+        # assert our lambda called the mock correctly
+        error_cb.assert_called_with(
+            "failure",
+            {},
+            {
+                "success_callback": None,
+                "failure_callback": error_cb,
+                "progress_callback": None,
+                "redirect_callback": None,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_redirect_callback(self, mock_request):
+        redir_cb = Mock()
+        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfiles/111", redirect_callback=redir_cb)
+        # simulate calling the requests on_redirect
+        req.on_redirect()(req, {})
+        # assert our lambda called the mock correctly
+        redir_cb.assert_called_with(
+            req,
+            None,
+            {
+                "success_callback": None,
+                "failure_callback": None,
+                "progress_callback": None,
+                "redirect_callback": redir_cb,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_progress_callback(self, mock_request):
+        progress_cb = Mock()
+        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfiles/111", progress_callback=progress_cb)
+        # simulate calling the requests on_progress
+        req.on_progress()(req, 0, 10)
+        # assert our lambda called the mock correctly
+        progress_cb.assert_called_with(
+            0,
+            10,
+            {
+                "success_callback": None,
+                "failure_callback": None,
+                "progress_callback": progress_cb,
+                "redirect_callback": None,
+            },
+        )
+
+    def tearDown(self):
+        podium_api.unregister_podium_application()
+
+
+class TestLogfilesGet(unittest.TestCase):
+    def setUp(self):
+        podium_api.register_podium_application("test_id", "test_secret")
+        self.token = PodiumToken("test_token", "test_type", 1)
+
+        self.result_json = {
+            "id": 111,
+            "URI": "https://podium.live/api/v1/logfile/111",
+            "file_key": "123456",
+            "eventdevice_id": 1234,
+            "status": 2,
+            "event_id": 333,
+            "event_url": "https://podium.live/api/v1/events/222",
+            "device_id": 444,
+            "device_url": "https://podium.live/api/v1/devices/333",
+            "created": "2023-09-04T09:38:18Z",
+        }
+        self.field_names = {
+            "id": "id",
+            "URI": "URI",
+            "file_key": "file_key",
+            "eventdevice_id": "eventdevice_id",
+            "status": "status",
+            "event_id": "event_id",
+            "event_url": "event_url",
+            "device_id": "device_id",
+            "device_url": "device_url",
+            "created": "created",
+        }
+
+        self.paged_logfile_json = {"total": 1, "logfiles": [self.result_json]}
+
+    def check_results_logfile(self):
+        for key in self.result_json:
+            if key in self.field_names:
+                rkey = self.field_names[key]
+            else:
+                rkey = key
+            self.assertEqual(getattr(self.result, rkey), self.result_json[key])
+
+    def check_results_paged_response(self):
+        result = self.result
+        self.assertEqual(result.total, 1)
+        self.assertEqual(result.next_uri, None)
+        self.assertEqual(result.prev_uri, None)
+        self.assertEqual(result.payload_name, "logfiles")
+        for logfile in result.logfiles:
+            self.result = logfile
+            self.check_results_logfile()
+
+    def test_get_logfile_from_json(self):
+        self.result = get_logfile_from_json(self.result_json)
+        self.check_results_logfile()
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_no_params(self, mock_request):
+        req = make_logfiles_get(
+            self.token,
+            expand=None,
+            success_callback=self.success_cb,
+        )
+        self.assertEqual(req.url, "https://podium.live/api/v1/logfiles")
+
+    def success_cb(self, result):
+        self.result = result
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_logfiles_get(self, mock_request):
+        req = make_logfiles_get(self.token, start=0, per_page=100, success_callback=self.success_cb)
+        self.assertEqual(req._method, "GET")
+        self.assertTrue("https://podium.live/api/v1/logfiles?" in req.url)
+        self.assertTrue("per_page=100" in req.url)
+        self.assertTrue("start=0" in req.url)
+        self.assertTrue("expand=True" in req.url)
+        self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
+        self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
+        self.assertEqual(req.req_headers["Accept"], "application/json")
+        # simulate successful request
+        req.on_success()(req, self.paged_logfile_json)
+        self.check_results_paged_response()
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_error_callback(self, mock_request):
+        error_cb = Mock()
+        req = make_logfiles_get(self.token, start=0, per_page=100, failure_callback=error_cb)
+        # simulate calling the requests on_error
+        req.on_error()(req, {})
+        # assert our lambda called the mock correctly
+        error_cb.assert_called_with(
+            "error",
+            {},
+            {
+                "success_callback": None,
+                "failure_callback": error_cb,
+                "progress_callback": None,
+                "redirect_callback": None,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_failure_callback(self, mock_request):
+        error_cb = Mock()
+        req = make_logfiles_get(self.token, start=0, per_page=100, failure_callback=error_cb)
+        # simulate calling the requests on_failure
+        req.on_failure()(req, {})
+        # assert our lambda called the mock correctly
+        error_cb.assert_called_with(
+            "failure",
+            {},
+            {
+                "success_callback": None,
+                "failure_callback": error_cb,
+                "progress_callback": None,
+                "redirect_callback": None,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_redirect_callback(self, mock_request):
+        redir_cb = Mock()
+        req = make_logfiles_get(self.token, start=0, per_page=100, redirect_callback=redir_cb)
+        # simulate calling the requests on_redirect
+        req.on_redirect()(req, {})
+        # assert our lambda called the mock correctly
+        redir_cb.assert_called_with(
+            req,
+            None,
+            {
+                "success_callback": None,
+                "failure_callback": None,
+                "progress_callback": None,
+                "redirect_callback": redir_cb,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_progress_callback(self, mock_request):
+        progress_cb = Mock()
+        req = make_logfiles_get(self.token, start=0, per_page=100, progress_callback=progress_cb)
         # simulate calling the requests on_progress
         req.on_progress()(req, 0, 10)
         # assert our lambda called the mock correctly

--- a/tests/test_logfiles.py
+++ b/tests/test_logfiles.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import unittest
+
+from mock import Mock, patch
+
+import podium_api
+from podium_api.logfiles import (
+    create_logfile_redirect_handler,
+    make_logfile_create,
+    make_logfile_get,
+)
+from podium_api.types.logfile import get_logfile_from_json
+from podium_api.types.redirect import get_redirect_from_json
+from podium_api.types.token import PodiumToken
+
+try:
+    from urllib.parse import urlencode
+except:
+    from urllib import urlencode
+
+
+class TestLogfileCreate(unittest.TestCase):
+    def setUp(self):
+        podium_api.register_podium_application("test_id", "test_secret")
+        self.token = PodiumToken("test_token", "test_type", 1)
+        self.result_json = {"location": "test/logfiles/1", "object_type": "logfile"}
+        self.field_names = {}
+
+    def check_results(self):
+        for key in self.result_json:
+            if key in self.field_names:
+                rkey = self.field_names[key]
+            else:
+                rkey = key
+            self.assertEqual(getattr(self.result, rkey), self.result_json[key])
+
+    def test_get_redirect_from_json(self):
+        self.result = get_redirect_from_json(self.result_json, "logfile")
+        self.check_results()
+
+    def success_cb(self, result):
+        self.result = result
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_logfile_create(self, mock_request):
+        req = make_logfile_create(self.token, 1, redirect_callback=self.success_cb)
+        self.assertEqual(req._method, "POST")
+        self.assertEqual(req.url, "https://podium.live/api/v1/logfiles")
+        self.assertEqual(req.req_body, urlencode({"friendship[user_id]": "1"}))
+        self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
+        self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
+        self.assertEqual(req.req_headers["Accept"], "application/json")
+        # simulate response header
+        req._resp_headers = self.result_json
+        # simulate successful request
+        req.on_redirect()(req, {})
+        self.check_results()
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_error_callback(self, mock_request):
+        error_cb = Mock()
+        req = make_logfile_create(self.token, 1, failure_callback=error_cb)
+        # simulate calling the requests on_error
+        req.on_error()(req, {})
+        # assert our lambda called the mock correctly
+        error_cb.assert_called_with(
+            "error",
+            {},
+            {
+                "success_callback": None,
+                "failure_callback": error_cb,
+                "progress_callback": None,
+                "redirect_callback": create_logfile_redirect_handler,
+                "_redirect_callback": None,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_failure_callback(self, mock_request):
+        error_cb = Mock()
+        req = make_logfile_create(self.token, 1, failure_callback=error_cb)
+        # simulate calling the requests on_failure
+        req.on_failure()(req, {})
+        # assert our lambda called the mock correctly
+        error_cb.assert_called_with(
+            "failure",
+            {},
+            {
+                "success_callback": None,
+                "failure_callback": error_cb,
+                "progress_callback": None,
+                "redirect_callback": create_logfile_redirect_handler,
+                "_redirect_callback": None,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_success_callback(self, mock_request):
+        success_cb = Mock()
+        req = make_logfile_create(self.token, 1, success_callback=success_cb)
+        # simulate calling the requests on_success
+        self.assertEqual(req.on_success, None)
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_progress_callback(self, mock_request):
+        progress_cb = Mock()
+        req = make_logfile_create(self.token, 1, progress_callback=progress_cb)
+        # simulate calling the requests on_progress
+        req.on_progress()(req, 0, 10)
+        # assert our lambda called the mock correctly
+        progress_cb.assert_called_with(
+            0,
+            10,
+            {
+                "success_callback": None,
+                "failure_callback": None,
+                "progress_callback": progress_cb,
+                "redirect_callback": create_logfile_redirect_handler,
+                "_redirect_callback": None,
+            },
+        )
+
+    def tearDown(self):
+        podium_api.unregister_podium_application()
+
+
+class TestLogfileGet(unittest.TestCase):
+    def setUp(self):
+        podium_api.register_podium_application("test_id", "test_secret")
+        self.token = PodiumToken("test_token", "test_type", 1)
+        self.result_json = {
+            "upload_url": "test/upload/url",
+            "file_key": 12345,
+            "eventdevice_id": 123,
+            "status": -1,
+        }
+        self.field_names = {
+            "upload_url": "upload_url",
+            "file_key": "file_key",
+            "eventdevice_id": "eventdevice_id",
+            "status": "status",
+        }
+
+    def check_results(self):
+        for key in self.result_json:
+            if key in self.field_names:
+                rkey = self.field_names[key]
+            else:
+                rkey = key
+            self.assertEqual(getattr(self.result, rkey), self.result_json[key])
+
+    def test_get_logfile_from_json(self):
+        self.result = get_logfile_from_json(self.result_json)
+        self.check_results()
+
+    def success_cb(self, result):
+        self.result = result
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_logfile_get(self, mock_request):
+        req = make_logfile_get(
+            self.token,
+            "https://podium.live/api/v1/logfile",
+            device_id=1234,
+            event_id=5678,
+            success_callback=self.success_cb,
+        )
+        self.assertEqual(req._method, "GET")
+        self.assertEqual(req.url, "https://podium.live/api/v1/logfile")
+        self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
+        self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
+        self.assertEqual(req.req_headers["Accept"], "application/json")
+        # simulate successful request
+        req.on_success()(req, {"logfile": self.result_json})
+        self.check_results()
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_error_callback(self, mock_request):
+        error_cb = Mock()
+        req = make_logfile_get(
+            self.token, "https://podium.live/api/v1/logfile", device_id=1234, event_id=5678, failure_callback=error_cb
+        )
+        # simulate calling the requests on_error
+        req.on_error()(req, {})
+        # assert our lambda called the mock correctly
+        error_cb.assert_called_with(
+            "error",
+            {},
+            {
+                "success_callback": None,
+                "failure_callback": error_cb,
+                "progress_callback": None,
+                "redirect_callback": None,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_failure_callback(self, mock_request):
+        error_cb = Mock()
+        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfile", failure_callback=error_cb)
+        # simulate calling the requests on_failure
+        req.on_failure()(req, {})
+        # assert our lambda called the mock correctly
+        error_cb.assert_called_with(
+            "failure",
+            {},
+            {
+                "success_callback": None,
+                "failure_callback": error_cb,
+                "progress_callback": None,
+                "redirect_callback": None,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_redirect_callback(self, mock_request):
+        redir_cb = Mock()
+        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfile", redirect_callback=redir_cb)
+        # simulate calling the requests on_redirect
+        req.on_redirect()(req, {})
+        # assert our lambda called the mock correctly
+        redir_cb.assert_called_with(
+            req,
+            None,
+            {
+                "success_callback": None,
+                "failure_callback": None,
+                "progress_callback": None,
+                "redirect_callback": redir_cb,
+            },
+        )
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_progress_callback(self, mock_request):
+        progress_cb = Mock()
+        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfile", progress_callback=progress_cb)
+        # simulate calling the requests on_progress
+        req.on_progress()(req, 0, 10)
+        # assert our lambda called the mock correctly
+        progress_cb.assert_called_with(
+            0,
+            10,
+            {
+                "success_callback": None,
+                "failure_callback": None,
+                "progress_callback": progress_cb,
+                "redirect_callback": None,
+            },
+        )
+
+    def tearDown(self):
+        podium_api.unregister_podium_application()

--- a/tests/test_logfiles.py
+++ b/tests/test_logfiles.py
@@ -44,10 +44,10 @@ class TestLogfileCreate(unittest.TestCase):
 
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_logfile_create(self, mock_request):
-        req = make_logfile_create(self.token, 1, redirect_callback=self.success_cb)
+        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, redirect_callback=self.success_cb)
         self.assertEqual(req._method, "POST")
         self.assertEqual(req.url, "https://podium.live/api/v1/logfiles")
-        self.assertEqual(req.req_body, urlencode({"friendship[user_id]": "1"}))
+        self.assertEqual(req.req_body, urlencode({"logfile[file_key]": "12345", "logfile[eventdevice_id]": 123}))
         self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
         self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
         self.assertEqual(req.req_headers["Accept"], "application/json")
@@ -60,7 +60,7 @@ class TestLogfileCreate(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_error_callback(self, mock_request):
         error_cb = Mock()
-        req = make_logfile_create(self.token, 1, failure_callback=error_cb)
+        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, failure_callback=error_cb)
         # simulate calling the requests on_error
         req.on_error()(req, {})
         # assert our lambda called the mock correctly
@@ -79,7 +79,7 @@ class TestLogfileCreate(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_failure_callback(self, mock_request):
         error_cb = Mock()
-        req = make_logfile_create(self.token, 1, failure_callback=error_cb)
+        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, failure_callback=error_cb)
         # simulate calling the requests on_failure
         req.on_failure()(req, {})
         # assert our lambda called the mock correctly
@@ -98,14 +98,14 @@ class TestLogfileCreate(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_success_callback(self, mock_request):
         success_cb = Mock()
-        req = make_logfile_create(self.token, 1, success_callback=success_cb)
+        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, success_callback=success_cb)
         # simulate calling the requests on_success
         self.assertEqual(req.on_success, None)
 
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_progress_callback(self, mock_request):
         progress_cb = Mock()
-        req = make_logfile_create(self.token, 1, progress_callback=progress_cb)
+        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, progress_callback=progress_cb)
         # simulate calling the requests on_progress
         req.on_progress()(req, 0, 10)
         # assert our lambda called the mock correctly
@@ -167,7 +167,7 @@ class TestLogfileGet(unittest.TestCase):
             success_callback=self.success_cb,
         )
         self.assertEqual(req._method, "GET")
-        self.assertEqual(req.url, "https://podium.live/api/v1/logfile")
+        self.assertEqual(req.url, "https://podium.live/api/v1/logfile?device_id=1234&event_id=5678")
         self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
         self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
         self.assertEqual(req.req_headers["Accept"], "application/json")
@@ -198,7 +198,9 @@ class TestLogfileGet(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_failure_callback(self, mock_request):
         error_cb = Mock()
-        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfile", failure_callback=error_cb)
+        req = make_logfile_get(
+            self.token, "https://podium.live/api/v1/logfile", device_id=1234, event_id=5678, failure_callback=error_cb
+        )
         # simulate calling the requests on_failure
         req.on_failure()(req, {})
         # assert our lambda called the mock correctly
@@ -216,7 +218,9 @@ class TestLogfileGet(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_redirect_callback(self, mock_request):
         redir_cb = Mock()
-        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfile", redirect_callback=redir_cb)
+        req = make_logfile_get(
+            self.token, "https://podium.live/api/v1/logfile", device_id=1234, event_id=5678, redirect_callback=redir_cb
+        )
         # simulate calling the requests on_redirect
         req.on_redirect()(req, {})
         # assert our lambda called the mock correctly
@@ -234,7 +238,13 @@ class TestLogfileGet(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_progress_callback(self, mock_request):
         progress_cb = Mock()
-        req = make_logfile_get(self.token, "https://podium.live/api/v1/logfile", progress_callback=progress_cb)
+        req = make_logfile_get(
+            self.token,
+            "https://podium.live/api/v1/logfile",
+            device_id=1234,
+            event_id=5678,
+            progress_callback=progress_cb,
+        )
         # simulate calling the requests on_progress
         req.on_progress()(req, 0, 10)
         # assert our lambda called the mock correctly

--- a/tests/test_logfiles.py
+++ b/tests/test_logfiles.py
@@ -8,7 +8,7 @@ import podium_api
 from podium_api.logfiles import (
     create_logfile_redirect_handler,
     make_logfile_create,
-    make_logfile_get,
+    make_logfile_new,
 )
 from podium_api.types.logfile import get_logfile_from_json
 from podium_api.types.redirect import get_redirect_from_json
@@ -125,7 +125,7 @@ class TestLogfileCreate(unittest.TestCase):
         podium_api.unregister_podium_application()
 
 
-class TestLogfileGet(unittest.TestCase):
+class TestLogfileNew(unittest.TestCase):
     def setUp(self):
         podium_api.register_podium_application("test_id", "test_secret")
         self.token = PodiumToken("test_token", "test_type", 1)
@@ -158,16 +158,15 @@ class TestLogfileGet(unittest.TestCase):
         self.result = result
 
     @patch("podium_api.asyncreq.UrlRequest.run")
-    def test_logfile_get(self, mock_request):
-        req = make_logfile_get(
+    def test_logfile_new(self, mock_request):
+        req = make_logfile_new(
             self.token,
-            "https://podium.live/api/v1/logfile",
             device_id=1234,
             event_id=5678,
             success_callback=self.success_cb,
         )
         self.assertEqual(req._method, "GET")
-        self.assertEqual(req.url, "https://podium.live/api/v1/logfile?device_id=1234&event_id=5678")
+        self.assertEqual(req.url, "https://podium.live/api/v1/logfiles/new?device_id=1234&event_id=5678")
         self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
         self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
         self.assertEqual(req.req_headers["Accept"], "application/json")
@@ -178,9 +177,7 @@ class TestLogfileGet(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_error_callback(self, mock_request):
         error_cb = Mock()
-        req = make_logfile_get(
-            self.token, "https://podium.live/api/v1/logfile", device_id=1234, event_id=5678, failure_callback=error_cb
-        )
+        req = make_logfile_new(self.token, device_id=1234, event_id=5678, failure_callback=error_cb)
         # simulate calling the requests on_error
         req.on_error()(req, {})
         # assert our lambda called the mock correctly
@@ -198,9 +195,7 @@ class TestLogfileGet(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_failure_callback(self, mock_request):
         error_cb = Mock()
-        req = make_logfile_get(
-            self.token, "https://podium.live/api/v1/logfile", device_id=1234, event_id=5678, failure_callback=error_cb
-        )
+        req = make_logfile_new(self.token, device_id=1234, event_id=5678, failure_callback=error_cb)
         # simulate calling the requests on_failure
         req.on_failure()(req, {})
         # assert our lambda called the mock correctly
@@ -218,9 +213,7 @@ class TestLogfileGet(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_redirect_callback(self, mock_request):
         redir_cb = Mock()
-        req = make_logfile_get(
-            self.token, "https://podium.live/api/v1/logfile", device_id=1234, event_id=5678, redirect_callback=redir_cb
-        )
+        req = make_logfile_new(self.token, device_id=1234, event_id=5678, redirect_callback=redir_cb)
         # simulate calling the requests on_redirect
         req.on_redirect()(req, {})
         # assert our lambda called the mock correctly
@@ -238,9 +231,8 @@ class TestLogfileGet(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_progress_callback(self, mock_request):
         progress_cb = Mock()
-        req = make_logfile_get(
+        req = make_logfile_new(
             self.token,
-            "https://podium.live/api/v1/logfile",
             device_id=1234,
             event_id=5678,
             progress_callback=progress_cb,


### PR DESCRIPTION
This adds the APIs for uploading and managing the list of logfile uploads. 

Upload mechanism:

1. identify an event
2. identify a device
3. have a racecapture log file ready
4. call PodiumApi.logfiles.new(event_id, device_id)
5. on success, success_callback response provides:
* upload_url
* file_key
* eventdevice_id
6. POST the log file using the upload_url
7. call PodiumApi.logfile.create(eventdevice_id, file_key)
8. on success, redirect_callback provides:
* an instance of the newly created logfile upload entry

Also includes some unrelated refactorings, and improvements to other unit tests.
