### PR TITLE
add source / source-ver to logfiles API

### DIFF
--- a/podium_api/logfiles.py
+++ b/podium_api/logfiles.py
@@ -213,6 +213,8 @@ def make_logfile_create(
     token,
     file_key,
     eventdevice_id,
+    source=None,
+    source_ver=None,
     success_callback=None,
     failure_callback=None,
     progress_callback=None,
@@ -247,8 +249,12 @@ def make_logfile_create(
         UrlRequest: The request being made.
 
     """
-    endpoint = "{}/api/v1/logfiles".format(podium_api.PODIUM_APP.podium_url)
+        endpoint = "{}/api/v1/logfiles".format(podium_api.PODIUM_APP.podium_url)
     body = {"logfile[file_key]": file_key, "logfile[eventdevice_id]": eventdevice_id}
+    if source is not None:
+        body["logfile[source]"] = source
+    if source_ver is not None:
+        body["logfile[source_ver]"] = source_ver
     header = get_json_header_token(token)
     return make_request_custom_success(
         endpoint,

--- a/podium_api/logfiles.py
+++ b/podium_api/logfiles.py
@@ -249,7 +249,7 @@ def make_logfile_create(
         UrlRequest: The request being made.
 
     """
-        endpoint = "{}/api/v1/logfiles".format(podium_api.PODIUM_APP.podium_url)
+    endpoint = "{}/api/v1/logfiles".format(podium_api.PODIUM_APP.podium_url)
     body = {"logfile[file_key]": file_key, "logfile[eventdevice_id]": eventdevice_id}
     if source is not None:
         body["logfile[source]"] = source

--- a/podium_api/logfiles.py
+++ b/podium_api/logfiles.py
@@ -213,8 +213,8 @@ def make_logfile_create(
     token,
     file_key,
     eventdevice_id,
-    source=None,
-    source_ver=None,
+    source,
+    source_ver,
     success_callback=None,
     failure_callback=None,
     progress_callback=None,
@@ -250,11 +250,12 @@ def make_logfile_create(
 
     """
     endpoint = "{}/api/v1/logfiles".format(podium_api.PODIUM_APP.podium_url)
-    body = {"logfile[file_key]": file_key, "logfile[eventdevice_id]": eventdevice_id}
-    if source is not None:
-        body["logfile[source]"] = source
-    if source_ver is not None:
-        body["logfile[source_ver]"] = source_ver
+    body = {
+        "logfile[file_key]": file_key,
+        "logfile[eventdevice_id]": eventdevice_id,
+        "logfile[source]": source,
+        "logfile[source_ver]": source_ver,
+    }
     header = get_json_header_token(token)
     return make_request_custom_success(
         endpoint,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name="podium_api",
     packages=["podium_api", "podium_api.types"],
-    version="0.2.0",
+    version="0.3.0",
     description="API for Podium Motorsports Platform http://podium.live",
     author="Autosport Labs",
     author_email="sales@autosportlabs.com",

--- a/tests/test_logfiles.py
+++ b/tests/test_logfiles.py
@@ -44,7 +44,7 @@ class TestLogfileCreate(unittest.TestCase):
     def success_cb(self, result):
         self.result = result
 
-    @patch("podium_api.asyncreq.UrlRequest.run")
+        @patch("podium_api.asyncreq.UrlRequest.run")
     def test_logfile_create(self, mock_request):
         req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, redirect_callback=self.success_cb)
         self.assertEqual(req._method, "POST")
@@ -58,6 +58,21 @@ class TestLogfileCreate(unittest.TestCase):
         # simulate successful request
         req.on_redirect()(req, {})
         self.check_results()
+
+    @patch("podium_api.asyncreq.UrlRequest.run")
+    def test_logfile_create_with_source_fields(self, mock_request):
+        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, source="rcp", source_ver="3.4.5", redirect_callback=self.success_cb)
+        self.assertEqual(req._method, "POST")
+        self.assertEqual(req.url, "https://podium.live/api/v1/logfiles")
+        expected = {"logfile[file_key]": "12345", "logfile[eventdevice_id]": 123, "logfile[source]": "rcp", "logfile[source_ver]": "3.4.5"}
+        self.assertEqual(req.req_body, urlencode(expected))
+        self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
+        self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
+        self.assertEqual(req.req_headers["Accept"], "application/json")
+        req._resp_headers = self.result_json
+        req.on_redirect()(req, {})
+        self.check_results()
+
 
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_error_callback(self, mock_request):

--- a/tests/test_logfiles.py
+++ b/tests/test_logfiles.py
@@ -44,7 +44,7 @@ class TestLogfileCreate(unittest.TestCase):
     def success_cb(self, result):
         self.result = result
 
-        @patch("podium_api.asyncreq.UrlRequest.run")
+    @patch("podium_api.asyncreq.UrlRequest.run")
     def test_logfile_create(self, mock_request):
         req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, redirect_callback=self.success_cb)
         self.assertEqual(req._method, "POST")
@@ -61,10 +61,22 @@ class TestLogfileCreate(unittest.TestCase):
 
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_logfile_create_with_source_fields(self, mock_request):
-        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, source="rcp", source_ver="3.4.5", redirect_callback=self.success_cb)
+        req = make_logfile_create(
+            self.token,
+            file_key="12345",
+            eventdevice_id=123,
+            source="rcp",
+            source_ver="3.4.5",
+            redirect_callback=self.success_cb,
+        )
         self.assertEqual(req._method, "POST")
         self.assertEqual(req.url, "https://podium.live/api/v1/logfiles")
-        expected = {"logfile[file_key]": "12345", "logfile[eventdevice_id]": 123, "logfile[source]": "rcp", "logfile[source_ver]": "3.4.5"}
+        expected = {
+            "logfile[file_key]": "12345",
+            "logfile[eventdevice_id]": 123,
+            "logfile[source]": "rcp",
+            "logfile[source_ver]": "3.4.5",
+        }
         self.assertEqual(req.req_body, urlencode(expected))
         self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
         self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
@@ -72,7 +84,6 @@ class TestLogfileCreate(unittest.TestCase):
         req._resp_headers = self.result_json
         req.on_redirect()(req, {})
         self.check_results()
-
 
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_error_callback(self, mock_request):

--- a/tests/test_logfiles.py
+++ b/tests/test_logfiles.py
@@ -46,28 +46,13 @@ class TestLogfileCreate(unittest.TestCase):
 
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_logfile_create(self, mock_request):
-        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, redirect_callback=self.success_cb)
-        self.assertEqual(req._method, "POST")
-        self.assertEqual(req.url, "https://podium.live/api/v1/logfiles")
-        self.assertEqual(req.req_body, urlencode({"logfile[file_key]": "12345", "logfile[eventdevice_id]": 123}))
-        self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
-        self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
-        self.assertEqual(req.req_headers["Accept"], "application/json")
-        # simulate response header
-        req._resp_headers = self.result_json
-        # simulate successful request
-        req.on_redirect()(req, {})
-        self.check_results()
-
-    @patch("podium_api.asyncreq.UrlRequest.run")
-    def test_logfile_create_with_source_fields(self, mock_request):
         req = make_logfile_create(
             self.token,
             file_key="12345",
             eventdevice_id=123,
+            redirect_callback=self.success_cb,
             source="rcp",
             source_ver="3.4.5",
-            redirect_callback=self.success_cb,
         )
         self.assertEqual(req._method, "POST")
         self.assertEqual(req.url, "https://podium.live/api/v1/logfiles")
@@ -81,14 +66,23 @@ class TestLogfileCreate(unittest.TestCase):
         self.assertEqual(req.req_headers["Content-Type"], "application/x-www-form-urlencoded")
         self.assertEqual(req.req_headers["Authorization"], "Bearer {}".format(self.token.token))
         self.assertEqual(req.req_headers["Accept"], "application/json")
+        # simulate response header
         req._resp_headers = self.result_json
+        # simulate successful request
         req.on_redirect()(req, {})
         self.check_results()
 
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_error_callback(self, mock_request):
         error_cb = Mock()
-        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, failure_callback=error_cb)
+        req = make_logfile_create(
+            self.token,
+            file_key="12345",
+            eventdevice_id=123,
+            source="rcp",
+            source_ver="3.4.5",
+            failure_callback=error_cb,
+        )
         # simulate calling the requests on_error
         req.on_error()(req, {})
         # assert our lambda called the mock correctly
@@ -107,7 +101,14 @@ class TestLogfileCreate(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_failure_callback(self, mock_request):
         error_cb = Mock()
-        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, failure_callback=error_cb)
+        req = make_logfile_create(
+            self.token,
+            file_key="12345",
+            eventdevice_id=123,
+            source="rcp",
+            source_ver="3.4.5",
+            failure_callback=error_cb,
+        )
         # simulate calling the requests on_failure
         req.on_failure()(req, {})
         # assert our lambda called the mock correctly
@@ -126,14 +127,28 @@ class TestLogfileCreate(unittest.TestCase):
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_success_callback(self, mock_request):
         success_cb = Mock()
-        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, success_callback=success_cb)
+        req = make_logfile_create(
+            self.token,
+            file_key="12345",
+            eventdevice_id=123,
+            source="rcp",
+            source_ver="3.4.5",
+            success_callback=success_cb,
+        )
         # simulate calling the requests on_success
         self.assertEqual(req.on_success, None)
 
     @patch("podium_api.asyncreq.UrlRequest.run")
     def test_progress_callback(self, mock_request):
         progress_cb = Mock()
-        req = make_logfile_create(self.token, file_key="12345", eventdevice_id=123, progress_callback=progress_cb)
+        req = make_logfile_create(
+            self.token,
+            file_key="12345",
+            eventdevice_id=123,
+            source="rcp",
+            source_ver="3.4.5",
+            progress_callback=progress_cb,
+        )
         # simulate calling the requests on_progress
         req.on_progress()(req, 0, 10)
         # assert our lambda called the mock correctly


### PR DESCRIPTION
Add the ability to specify the source device (source) and it's version (source_ver) when uploading log files. 

The source / source_ver values are specified when the final POST is sent to the server after the log file has been uploaded.

